### PR TITLE
Quote resource NetworkManager

### DIFF
--- a/manifests/role/node.pp
+++ b/manifests/role/node.pp
@@ -22,7 +22,7 @@ class openshift::role::node (
     #
     # https://github.com/openshift/openshift-ansible/issues/1807
     #
-    Package[NetworkManager] ->
+    Package['NetworkManager'] ->
     service { 'openshift-networkmanager':
       name   => 'NetworkManager',
       ensure => 'running',


### PR DESCRIPTION
A string has to be quoted. Puppet 4 will not work without it and
Puppet 3 turns it into a string automatically.